### PR TITLE
Fix elasticsearch helm deployment env format

### DIFF
--- a/chart/mist/templates/elasticsearch-deployment.yaml
+++ b/chart/mist/templates/elasticsearch-deployment.yaml
@@ -26,8 +26,8 @@ spec:
         image: elasticsearch:5.6.16
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
-          name: ES_JAVA_OPTS
-          value: "-Dlog4j2.formatMsgNoLookups=true"
+          - name: ES_JAVA_OPTS
+            value: "-Dlog4j2.formatMsgNoLookups=true"
         resources:
           requests:
             memory: 2500Mi


### PR DESCRIPTION
Getting the following error when installing the mist-ce Helm chart:

Chart Version: 4.6.2

> Error: INSTALLATION FAILED: unable to build kubernetes objects from release manifest: error validating "": error validating data: ValidationError(Deployment.spec.template.spec.containers[0].env): invalid type for io.k8s.api.core.v1.Container.env: got "map", expected "array"

Command run:
```
helm install uno-mist mist/mist-ce --set http.host=<my-host> --set http.tlsSecret=<my-secret>
```



After doing some digging I found that the error is in the Elasticsearch Deployment manifest.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mistio/mist-ce/1029)
<!-- Reviewable:end -->
